### PR TITLE
Add Beaker tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.swp
 *.vim
+log/
+.bundle/
+vendor/
+.vagrant/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
 MethodLength:
   CountComments: false
   Max: 20
+Metrics/LineLength:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
   gem 'puppet', '~> 3.7.0'
   gem 'puppetlabs_spec_helper'
   gem 'rubocop'
+  gem 'beaker-rspec'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,72 +1,290 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
-    ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    CFPropertyList (2.3.1)
+    activesupport (4.2.3)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.8)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
+    aws-sdk (1.64.0)
+      aws-sdk-v1 (= 1.64.0)
+    aws-sdk-v1 (1.64.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    beaker (2.18.3)
+      aws-sdk (~> 1.57)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25)
+      google-api-client (~> 0.8)
+      hocon (~> 0.1)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
+      rbvmomi (~> 1.8)
+      rsync (~> 1.0.9)
+      unf (~> 0.1)
+    beaker-rspec (5.2.0)
+      beaker (~> 2.0)
+      rspec
+      serverspec (~> 2)
+      specinfra (~> 2)
+    builder (3.2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    facter (2.4.1)
-      CFPropertyList (~> 2.2.6)
+    docker-api (1.22.2)
+      excon (>= 0.38.0)
+      json
+    excon (0.45.4)
+    extlib (0.9.16)
+    facter (1.7.6)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.32.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-ecloud (= 0.1.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.7.4)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.8.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.32.0)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.1.1)
+      fog-core
+      fog-xml
+    fog-google (0.0.7)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.1)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    google-api-client (0.8.6)
+      activesupport (>= 3.2)
+      addressable (~> 2.3)
+      autoparse (~> 0.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      googleauth (~> 0.3)
+      launchy (~> 2.4)
+      multi_json (~> 1.10)
+      retriable (~> 1.4)
+      signet (~> 0.6)
+    googleauth (0.4.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (= 1.11)
+      signet (~> 0.6)
     hiera (1.3.4)
       json_pure
+    hocon (0.9.3)
+    i18n (0.7.0)
+    inflecto (0.0.2)
+    inifile (2.0.2)
+    ipaddress (0.8.0)
+    json (1.8.3)
     json_pure (1.8.2)
+    jwt (1.5.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    little-plugger (1.1.3)
+    logging (2.0.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    memoist (0.12.0)
     metaclass (0.0.4)
     method_source (0.8.2)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
+    minitest (5.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    parser (2.2.0.3)
+    multi_json (1.11.0)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-telnet (0.1.1)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    open_uri_redirections (0.2.1)
+    parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
-    powerpack (0.1.0)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puppet (3.7.4)
+    puppet (3.7.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
     puppet-lint (1.1.0)
-    puppet-syntax (1.4.1)
+    puppet-syntax (2.0.0)
       rake
-    puppetlabs_spec_helper (0.8.2)
+    puppetlabs_spec_helper (0.10.3)
       mocha
       puppet-lint
       puppet-syntax
       rake
-      rspec
       rspec-puppet
     rainbow (2.0.0)
     rake (10.4.2)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    retriable (1.4.1)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.0)
+    rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    rspec-expectations (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
-    rspec-mocks (3.2.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
-    rspec-puppet (1.0.1)
+    rspec-puppet (2.2.0)
       rspec
-    rspec-support (3.2.1)
-    rubocop (0.29.1)
+    rspec-support (3.2.2)
+    rsync (1.0.9)
+    rubocop (0.32.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.0.1, < 3.0)
+      parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.1)
+    ruby-progressbar (1.7.5)
+    serverspec (2.20.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.38)
+    sfl (2.2)
+    signet (0.6.1)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
     slop (3.6.0)
+    specinfra (2.40.0)
+      net-scp
+      net-ssh (~> 2.7)
+      net-telnet
+      sfl
+    thread_safe (0.3.5)
+    trollop (2.1.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  beaker-rspec
   pry
   puppet (~> 3.7.0)
   puppetlabs_spec_helper

--- a/spec/acceptance/interface_policy_spec.rb
+++ b/spec/acceptance/interface_policy_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'interface_policy' do
-
   context 'providing a valid set of interfaces' do
-
     it 'should remove an interface not in the set' do
       pp = <<-EOS
         cumulus_interface { 'lo':
@@ -15,12 +13,12 @@ describe 'interface_policy' do
         }
 
         cumulus_interface { 'swp2':
-          ipv4 => ['10.30.1.1'],
+          ipv4   => ['10.30.1.1'],
           notify => Service['networking'],
         }
 
         cumulus_interface { 'swp3':
-          ipv4 => ['10.30.1.2'],
+          ipv4   => ['10.30.1.2'],
           notify => Service['networking'],
         }
 
@@ -39,15 +37,15 @@ describe 'interface_policy' do
 
         cumulus_interface_policy{ 'policy':
           allowed => ['lo', 'eth0', 'swp2'],
-          notify => Service['networking'],
+          notify  => Service['networking'],
           require => [Cumulus_interface['lo'], Cumulus_interface['eth0'], Cumulus_interface['swp2'], Cumulus_interface['swp3']],
         }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, catch_failures: true)
     end
 
-    ['lo', 'eth0', 'swp2'].each do |intf|
+    %w(lo eth0 swp2).each do |intf|
       describe interface(intf) do
         it { should exist }
         it { should be_up } if intf != 'lo'
@@ -66,9 +64,7 @@ describe 'interface_policy' do
       it { should_not exist }
     end
 
-    #it 'should retain interfaces that are in the set' do
-    #end
-
+    # it 'should retain interfaces that are in the set' do
+    # end
   end
-
 end

--- a/spec/acceptance/interface_policy_spec.rb
+++ b/spec/acceptance/interface_policy_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper_acceptance'
+
+describe 'interface_policy' do
+
+  context 'providing a valid set of interfaces' do
+
+    it 'should remove an interface not in the set' do
+      pp = <<-EOS
+        cumulus_interface { 'lo':
+          addr_method => 'loopback',
+        }
+
+        cumulus_interface { 'eth0':
+          addr_method => 'dhcp',
+        }
+
+        cumulus_interface { 'swp2':
+          ipv4 => ['10.30.1.1'],
+          notify => Service['networking'],
+        }
+
+        cumulus_interface { 'swp3':
+          ipv4 => ['10.30.1.2'],
+          notify => Service['networking'],
+        }
+
+        file { '/etc/network/interfaces':
+          content => "source /etc/network/interfaces.d/*\n",
+        }
+
+        service { 'networking':
+          ensure     => running,
+          hasrestart => true,
+          restart    => '/sbin/ifreload -a',
+          enable     => true,
+          hasstatus  => false,
+          require    => File['/etc/network/interfaces'],
+        }
+
+        cumulus_interface_policy{ 'policy':
+          allowed => ['lo', 'eth0', 'swp2'],
+          notify => Service['networking'],
+          require => [Cumulus_interface['lo'], Cumulus_interface['eth0'], Cumulus_interface['swp2'], Cumulus_interface['swp3']],
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    ['lo', 'eth0', 'swp2'].each do |intf|
+      describe interface(intf) do
+        it { should exist }
+        it { should be_up } if intf != 'lo'
+      end
+
+      describe file("/etc/network/interfaces.d/#{intf}") do
+        it { should be_file }
+      end
+    end
+
+    describe interface('swp3') do
+      it { should_not be_up }
+    end
+
+    describe file('/etc/network/interfaces/swp3') do
+      it { should_not exist }
+    end
+
+    #it 'should retain interfaces that are in the set' do
+    #end
+
+  end
+
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,9 @@
+HOSTS:
+  cumulus-vx-2.5.3:
+    roles:
+      - master
+    platform: debian-253-amd64
+    box: cumulus-vx-2.5.3
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,23 @@
+require 'beaker-rspec'
+require 'pry'
+
+hosts.each do |host|
+  # Install Puppet
+  on host, 'apt-get update && apt-get install -y puppet'
+end
+
+RSpec.configure do |c|
+  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module
+    puppet_module_install(:source => module_root, :module_name => 'cumulus_interface_policy')
+    hosts.each do |host|
+      on host, puppet('module','install','cumuluslinux-cumulus_interfaces'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,10 +14,10 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module
-    puppet_module_install(:source => module_root, :module_name => 'cumulus_interface_policy')
+    puppet_module_install(source: module_root, module_name: 'cumulus_interface_policy')
     hosts.each do |host|
-      on host, puppet('module','install','cumuluslinux-cumulus_interfaces'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'cumuluslinux-cumulus_interfaces'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
     end
   end
 end


### PR DESCRIPTION
Use Beaker to provide acceptance tests. Most of the setup & tests are ported from the existing Chef tests.